### PR TITLE
fix: 修复 arm 芯片下 pnpm 安装报错的问题

### DIFF
--- a/.changeset/cyan-carrots-applaud.md
+++ b/.changeset/cyan-carrots-applaud.md
@@ -1,0 +1,8 @@
+---
+'@antv/xflow-core': patch
+'@antv/xflow': patch
+'@antv/xflow-extension': patch
+'@antv/xflow-hook': patch
+---
+
+fix: 修复 arm 芯片下 pnpm 安装报错的问题

--- a/.changeset/violet-camels-juggle.md
+++ b/.changeset/violet-camels-juggle.md
@@ -1,8 +1,0 @@
----
-'@antv/xflow': patch
-'@antv/xflow-core': patch
-'@antv/xflow-extension': patch
-'@antv/xflow-hook': patch
----
-
-chore: enable importHelper option in tsconfig.json

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "pnpm": {
     "overrides": {
-      "colors": "1.2.5"
+      "colors": "1.2.5",
+      "sharp": "^0.29.0"
     }
   },
   "dependencies": {


### PR DESCRIPTION
### 问题描述
在 `M1` 的 `mac` 环境下使用 `pnpm i` 会报错

![image](https://user-images.githubusercontent.com/42743672/153821757-92694ebf-6c8a-4ca4-b7d2-6d1e6edff1a6.png)

### 问题追溯
查看 [sharp官网关于M1芯片的说明](https://sharp.pixelplumbing.com/install#apple-m1) 后得知，`^0.29.x` 版本才支持 `ARM64`

### 解决方案
在 `package.json` 中，利用 `pnpm.overrides` 字段，将 `sharp` 版本锁定在 `0.29.x` 以上