### PR TITLE
dndPanel add collapseBtn & update sharp version

### DIFF
--- a/.changeset/moody-ghosts-worry.md
+++ b/.changeset/moody-ghosts-worry.md
@@ -1,0 +1,8 @@
+---
+'@antv/xflow-core': major
+'@antv/xflow-extension': major
+'@antv/xflow': major
+'@antv/xflow-hook': major
+---
+
+Add NodeDndPanel collapse button

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "pnpm": {
     "overrides": {
-      "colors": "1.2.5"
+      "colors": "1.2.5",
+      "sharp": "^0.29.0"
     }
   },
   "dependencies": {

--- a/packages/xflow-core/src/hooks/contributions/graph.ts
+++ b/packages/xflow-core/src/hooks/contributions/graph.ts
@@ -67,12 +67,16 @@ export class GraphEventContribution implements IHookContribution<IHooks> {
       hooks.afterGraphInit.registerHook({
         name: 'add auto resize event',
         handler: async args => {
-          const { commandService } = args
+          const { commandService, options, graph } = args
           const resizeHandler = throttle(() => {
             commandService.executeCommand(XFlowGraphCommands.GRAPH_RESIZE.id, {})
           })
 
           window.addEventListener('resize', resizeHandler)
+
+          const { rootContainer }  = options;
+          const resizeObserver = new ResizeObserver(() => graph.resize(rootContainer.clientWidth))
+          rootContainer && resizeObserver.observe(rootContainer)
 
           toDispose.push(
             Disposable.create(() => {

--- a/packages/xflow-core/src/hooks/interface.ts
+++ b/packages/xflow-core/src/hooks/interface.ts
@@ -6,6 +6,7 @@ import type { IModelService } from '../model-service/interface'
 import { HookHub } from '@antv/xflow-hook'
 import { Syringe } from 'mana-syringe'
 import type { EventArgs } from '@antv/x6/es/graph/events'
+import type { IGraphConfig } from '../xflow-main/graph/config'
 export interface IRegsiterHookFn<T = IHooks> {
   (hooks: T): Disposable
 }
@@ -52,7 +53,8 @@ export type IEventSubscription = Disposable[]
 export interface IGeneralAppService {
   graph: Graph
   commandService: IGraphCommandService
-  modelService: IModelService
+  modelService: IModelService,
+  options: IGraphConfig
 }
 
 export const initHooks = () => ({

--- a/packages/xflow-core/src/xflow-main/graph/graph-provider.tsx
+++ b/packages/xflow-core/src/xflow-main/graph/graph-provider.tsx
@@ -99,6 +99,7 @@ export class GraphManager implements IGraphManager {
         graph,
         commandService,
         modelService,
+        options,
       })
 
       graphDefer.resolve(graph)
@@ -129,6 +130,7 @@ export class GraphManager implements IGraphManager {
             graph,
             commandService,
             modelService,
+            options,
           })
           this.graphMap.delete(graphId)
           graph.dispose()

--- a/packages/xflow-extension/src/canvas-collapse-panel/index.tsx
+++ b/packages/xflow-extension/src/canvas-collapse-panel/index.tsx
@@ -1,25 +1,28 @@
 import type { IProps, ILayoutProps } from './interface'
-import React from 'react'
+import React, { useState, useCallback } from 'react'
 import { useXflowPrefixCls } from '@antv/xflow-core'
 import { WorkspacePanel } from '../base-panel'
 import { CollapsePanelBody } from './panel-body'
 import { NodePanelHeader } from './panel-header'
 import { NodePanelFooter } from './panel-footer'
+import { NodePanelCollapseBtn } from './panel-collapse-btn'
 import { usePanelLyaoutStyle } from './utils'
 import { useCollapsePanelData } from './service'
 import { NsCollapsePanelModel } from './interface'
 import * as NsNodeCollapsePanel from './interface'
 
 const CollapsePanelMain: React.FC<IProps> = props => {
-  const { headerStyle, bodyStyle, footerStyle } = usePanelLyaoutStyle(props as ILayoutProps)
+  const { headerStyle, bodyStyle, footerStyle } = usePanelLyaoutStyle(
+    props as ILayoutProps,
+  )
   const { state, onActiveKeyChange, onKeywordChange } = useCollapsePanelData(props)
-
+  
   return (
     <>
       <NodePanelHeader
         {...props}
         state={state}
-        style={headerStyle}
+        style={headerStyle} 
         onKeywordChange={onKeywordChange}
       />
       <CollapsePanelBody
@@ -28,16 +31,57 @@ const CollapsePanelMain: React.FC<IProps> = props => {
         style={bodyStyle}
         onActiveKeyChange={onActiveKeyChange}
       />
-      <NodePanelFooter {...props} state={state} style={footerStyle} />
+      <NodePanelFooter
+        {...props}
+        state={state}
+        style={footerStyle}
+      />
     </>
   )
 }
 
 const NodeCollapsePanel: React.FC<IProps> = props => {
+  const { position, collapsible, onCollapseChange } = props
+  const { width = 200, left } = position
   const prefixClz = useXflowPrefixCls('collapse-panel')
+
+  const [isCollapsed, setIsCollapsed] = useState(false)
+
+  const handleBtnClick = useCallback(() => {
+    setIsCollapsed(!isCollapsed)
+    onCollapseChange(!isCollapsed)
+  }, [isCollapsed, onCollapseChange])
+
   return (
-    <WorkspacePanel {...props} className={prefixClz}>
+    <WorkspacePanel 
+      {...props} 
+      className={prefixClz} 
+      position={{...position, left: !isCollapsed ? left : -width }}
+      style={{transition: 'left 0.5s'}}
+    >
       <CollapsePanelMain {...props} prefixClz={prefixClz} />
+
+      {collapsible && (
+        <NodePanelCollapseBtn
+          {...props}
+          prefixClz={prefixClz}
+          isCollapsed={isCollapsed}
+          onCollapseBtnClick={handleBtnClick}
+          style={{
+            position: 'absolute',
+            zIndex: 1,
+            width: 13,
+            right: -13,
+            bottom: 20,
+            padding: '12px 0px',
+            textAlign: 'center',
+            borderWidth: '1px 1px 1px 0',
+            borderStyle: 'solid solid solid',
+            borderColor: 'rgb(232, 232, 232) rgb(232, 232, 232) rgb(232, 232, 232)',
+            cursor: 'pointer',
+          }}
+        />
+      )}
     </WorkspacePanel>
   )
 }

--- a/packages/xflow-extension/src/canvas-collapse-panel/interface.tsx
+++ b/packages/xflow-extension/src/canvas-collapse-panel/interface.tsx
@@ -59,6 +59,12 @@ export interface IProps extends Partial<ILayoutProps> {
   nodeDataService: INodeDataService
   /** dnd的配置项 */
   x6NodeFactory?: (args: INodeFactoryArgs) => X6Node
+  /** 是否可以折叠 */
+  collapsible?: boolean
+  /** 折叠的 onChange 方法 */
+  onCollapseChange?: (isCollapsed: boolean) => void
+  /** collapseBtn 的样式 */
+  collapseButtonStyle?: React.CSSProperties
 }
 
 /** drop节点的回调，通过回调创建画布的节点 */

--- a/packages/xflow-extension/src/canvas-collapse-panel/panel-collapse-btn.tsx
+++ b/packages/xflow-extension/src/canvas-collapse-panel/panel-collapse-btn.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import type { IProps } from './interface'
+import { CaretLeftOutlined } from '@ant-design/icons'
+
+export interface ICollapseBtnProps extends IProps {
+  isCollapsed: boolean
+  onCollapseBtnClick: () => void
+}
+
+/** collapseBtn */
+export const NodePanelCollapseBtn: React.FC<ICollapseBtnProps> = props => {
+  const { prefixClz, onCollapseBtnClick, isCollapsed, collapseButtonStyle, style } = props
+
+  return (
+    <React.Fragment>
+      <div
+        className={`${prefixClz}-header`}
+        style={{ ...style, ...collapseButtonStyle }}
+        onClick={onCollapseBtnClick}
+      >
+        <CaretLeftOutlined rotate={isCollapsed ? 180 : 0}/>
+      </div>
+    </React.Fragment>
+  )
+}

--- a/packages/xflow-extension/src/canvas-collapse-panel/service.tsx
+++ b/packages/xflow-extension/src/canvas-collapse-panel/service.tsx
@@ -33,7 +33,7 @@ export const executeCollapsePanelCommand = (
 
 /** 方便其他组件执行Command改变Panel内部状态 */
 export const useCollapsePanelData = (props: IProps) => {
-  const { nodeDataService, searchService } = props
+  const { collapsible, nodeDataService, searchService, onCollapseChange } = props
   const { modelService } = useXFlowApp()
   /** 创建model */
   const [state, setState, panelModel] = createComponentModel<NsCollapsePanelModel.IState>({
@@ -114,8 +114,10 @@ export const useCollapsePanelData = (props: IProps) => {
   )
   return {
     state,
+    collapsible,
     setState,
     onKeywordChange,
     onActiveKeyChange,
+    onCollapseChange,
   }
 }


### PR DESCRIPTION
## 1. sharp 版本升级
### 问题描述
在 `M1` 的 `mac` 环境下使用 `pnpm i` 会报错

![image](https://user-images.githubusercontent.com/42743672/153821757-92694ebf-6c8a-4ca4-b7d2-6d1e6edff1a6.png)

### 问题追溯
查看 [sharp官网关于M1芯片的说明](https://sharp.pixelplumbing.com/install#apple-m1) 后得知，`^0.29.x` 版本才支持 `ARM64`

### 解决方案
在 `package.json` 中，利用 `pnpm.overrides` 字段，将 `sharp` 版本锁定在 `0.29.x` 以上

## 2. 新增Dnd collapse btn
### 新增属性
```ts
/** 是否可以折叠 */
collapsible?: boolean
/** 折叠的 onChange 方法 */
onCollapseChange?: (isCollapsed: boolean) => void
/** collapseBtn 的样式 */
collapseButtonStyle?: React.CSSProperties
```
### 使用方法
```ts
const XFlowDemo: React.FC<{}> = props => {
  const collapsePanelWidth = 290
  const graphConfig = useGraphConfig(props)

  const [menuWidth, setMenuWidth] = useState(collapsePanelWidth)

  const onCollapseChange = (isCollapsed: boolean) => {
    setMenuWidth(isCollapsed ? 0 : collapsePanelWidth)
  }

  return (
    <XFlow onLoad={onLoad} className="xflow-workspace">
      <NodeCollapsePanel
        header={<h4 className="dnd-panel-header"> 组件面板 </h4>}
        footer={<div> Foorter </div>}
        onNodeDrop={panelConfig.onNodeDrop}
        nodeDataService={panelConfig.nodeDataService}
        position={{ top: 0, bottom: 0, left: 0, width: menuWidth }}
        collapsible={true}
        onCollapseChange={onCollapseChange}
        collapseButtonStyle={{}}
      />
      <XFlowCanvas
        config={graphConfig}
        position={{ top: 0, bottom: 0, left: menuWidth, right: 0 }}
      />
    </XFlow>
  )
}
```