### PR TITLE
feat: update x6 to 1.30.1

### DIFF
--- a/packages/xflow-core/package.json
+++ b/packages/xflow-core/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@antv/layout": "^0.1.22",
-    "@antv/x6": "^1.29.6",
+    "@antv/x6": "^1.30.1",
     "@antv/x6-react-components": "^1.1.15",
     "@antv/x6-react-shape": "^1.5.2",
     "@babel/core": "^7.16.5",
@@ -89,7 +89,7 @@
   },
   "peerDependencies": {
     "@ant-design/icons": "^4.6.0",
-    "@antv/x6": "^1.12.11",
+    "@antv/x6": "^1.30.1",
     "@antv/x6-react-components": "^1.1.15",
     "@antv/x6-react-shape": "^1.2.5",
     "antd": "^4.6.3",

--- a/packages/xflow-docs/package.json
+++ b/packages/xflow-docs/package.json
@@ -54,7 +54,7 @@
   "devDependencies": {
     "@ant-design/icons": "^4.7.0",
     "@antv/layout": "^0.1.24",
-    "@antv/x6": "^1.29.6",
+    "@antv/x6": "^1.30.1",
     "@antv/x6-react-components": "^1.1.15",
     "@antv/x6-react-shape": "^1.5.2",
     "@testing-library/jest-dom": "^5.16.1",

--- a/packages/xflow-extension/package.json
+++ b/packages/xflow-extension/package.json
@@ -47,7 +47,7 @@
     "reflect-metadata": "^0.1.13"
   },
   "devDependencies": {
-    "@antv/x6": "^1.29.6",
+    "@antv/x6": "^1.30.1",
     "@antv/x6-react-components": "^1.1.15",
     "@antv/x6-react-shape": "^1.5.2",
     "@rollup/plugin-commonjs": "^20.0.0",
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "@ant-design/icons": "^4.6.0",
-    "@antv/x6": "^1.12.11",
+    "@antv/x6": "^1.30.1",
     "@antv/x6-react-components": "^1.1.15",
     "@antv/x6-react-shape": "^1.2.5",
     "antd": "^4.6.3",

--- a/packages/xflow/package.json
+++ b/packages/xflow/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@antv/layout": "^0.1.22",
-    "@antv/x6": "^1.29.6",
+    "@antv/x6": "^1.30.1",
     "@antv/x6-react-components": "^1.1.15",
     "@antv/x6-react-shape": "^1.5.2",
     "@antv/xflow-core": "workspace:*",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

X6 1.30.1 版本修复了一个[重要的小地图展示问题](https://github.com/antvis/X6/pull/1832)。所以需要更新一下 X6 的版本。