### PR TITLE
fix: updateEdge  when label is a own-property

### DIFF
--- a/.changeset/green-ducks-carry.md
+++ b/.changeset/green-ducks-carry.md
@@ -1,0 +1,5 @@
+---
+'@antv/xflow-core': major
+---
+
+fix updateEdge when label is a own-property

--- a/packages/xflow-core/src/command-contributions/edge/edge-update.ts
+++ b/packages/xflow-core/src/command-contributions/edge/edge-update.ts
@@ -89,10 +89,12 @@ export class UpdateEdgeCommand implements ICommand {
 
         const x6Edge = x6Graph?.getCellById(edgeConfig?.id) as X6Edge
         x6Edge?.setData(edgeConfig, options)
-        if (edgeConfig?.label) {
+        
+        if (edgeConfig?.hasOwnProperty('label')) {
           // 默认更新edge的第一个label
           await updateEdgeLabelService(x6Edge, edgeConfig, options)
         }
+
         if (isBoolean(edgeConfig?.visible)) {
           x6Edge.setVisible(edgeConfig?.visible)
         }


### PR DESCRIPTION
- 修复updateEdge时 当edgeConfig中存在label属性 但为空时 不执行 updateEdgeLabelService