### PR TITLE
fix: 修复边被重复删除导致edge is not exist报错的问题

### DIFF
--- a/packages/xflow-core/src/command-contributions/graph/graph-render.ts
+++ b/packages/xflow-core/src/command-contributions/graph/graph-render.ts
@@ -225,9 +225,17 @@ export class GraphRenderCommand implements ICommand {
         await commandService.executeCommand(XFlowNodeCommands.DEL_NODE.id, { nodeConfig: nodeData })
       }
     }
-    for (const removeEdge of removeEdges) {
-      const edgeData = removeEdge?.getData()
-      await commandService.executeCommand(XFlowEdgeCommands.DEL_EDGE.id, { edgeConfig: edgeData })
+    /** 节点删除会同步删除其关联的边, 获取当前边的集合, 判断该边是否已经删除 */
+    const allEdges = x6Graph.getEdges()
+    if (allEdges.length > 0) {
+      for (const removeEdge of removeEdges) {
+        if (allEdges.includes(removeEdge)) {
+          const edgeData = removeEdge?.getData()
+          await commandService.executeCommand(XFlowEdgeCommands.DEL_EDGE.id, {
+            edgeConfig: edgeData,
+          })
+        }
+      }
     }
 
     if (x6Graph?.isFrozen()) {

--- a/packages/xflow-core/src/command-contributions/node/node-del.ts
+++ b/packages/xflow-core/src/command-contributions/node/node-del.ts
@@ -51,7 +51,7 @@ export namespace NsDelNode {
 @injectable({
   token: { token: ICommandHandler, named: NsDelNode.command.id },
 })
-/** 创建节点命令 */
+/** 删除节点命令 */
 export class DelNodeCommand implements ICommand {
   /** api */
   @inject(ICommandContextProvider) contextProvider: ICommand['contextProvider']


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

修复边被重复删除导致edge is not exist报错的问题
issue: https://github.com/antvis/XFlow/issues/255
原因: 节点删除会同步删除其关联的边, 导致再接下来的边删除操作中重复删除，控制台输出edge is not exist报错

### Description

<!--- Describe your changes in detail -->
1. GraphRenderCommand 中在边删除操作中新增判断
2. DelNodeCommand修改注释 创建节点命令 为 删除节点命令
### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
