### PR TITLE
docs: targetPortId comment

### DIFF
--- a/packages/xflow-core/src/interface.ts
+++ b/packages/xflow-core/src/interface.ts
@@ -79,7 +79,7 @@ export namespace NsGraph {
     target: string
     /** 边的上游节点的锚点Id */
     sourcePortId?: string
-    /** 边的上游节点的锚点Id */
+    /** 边的下游节点的锚点Id */
     targetPortId?: string
     /** 边上label */
     label?: string

--- a/packages/xflow-docs/docs/api/interface/index.md
+++ b/packages/xflow-docs/docs/api/interface/index.md
@@ -166,7 +166,7 @@ export interface IEdgeConfig {
   target: string
   /** 边的上游节点的锚点Id */
   sourcePortId?: string
-  /** 边的上游节点的锚点Id */
+  /** 边的下游节点的锚点Id */
   targetPortId?: string
   /** 边上label */
   label?: string


### PR DESCRIPTION
### Description

targetPortId 描述改为 “边的下游节点的锚点Id”