### PR TITLE
fix: 修复流程图在react 18下卡死的问题

### DIFF
--- a/packages/xflow-extension/src/canvas-dag-extension/module.ts
+++ b/packages/xflow-extension/src/canvas-dag-extension/module.ts
@@ -6,7 +6,8 @@ import { DagHooksContribution } from './contributions/dag'
 import { QueryGraphStatusCommand } from './contributions/command'
 export * from './x6-extension/edge'
 export * from './x6-extension/node'
-import { IComponentConfig, IProps } from './interface'
+import type { IProps } from './interface';
+import { IComponentConfig } from './interface'
 
 /** 依赖扩展模块，必须要加载 */
 const createDagExtensionModule: IExtensionModule<IProps>['createModule'] = config => {

--- a/packages/xflow-extension/src/canvas-node-tree-panel/panel-body.tsx
+++ b/packages/xflow-extension/src/canvas-node-tree-panel/panel-body.tsx
@@ -77,8 +77,11 @@ export const NodeTitle = (props: ITitleProps) => {
   const [isVisible, setVisible] = useState(false)
   const [appContainer, setAppContainer] = useState<HTMLElement>()
   const { getGraphConfig } = useXFlowApp()
-  getGraphConfig().then(graphConfig => {
-    setAppContainer(graphConfig.appContainer)
+
+  React.useEffect(() => {
+    getGraphConfig().then(graphConfig => {
+      setAppContainer(graphConfig.appContainer)
+    })
   })
 
   const {
@@ -150,8 +153,11 @@ export const NodePanelBody: React.FC<IBodyProps> = props => {
   const [dnd, setDnd] = React.useState<Addon.Dnd>()
 
   const [graph, setGraph] = React.useState<Graph>()
-  graphProvider.getGraphInstance().then(x6Graph => {
-    setGraph(x6Graph)
+
+  React.useEffect(() => {
+    graphProvider.getGraphInstance().then(x6Graph => {
+      setGraph(x6Graph)
+    })
   })
 
   React.useEffect(() => {
@@ -269,7 +275,7 @@ export const NodePanelBody: React.FC<IBodyProps> = props => {
         {state.searchList.length > 0 && (
           <ul className={`${prefixClz}-body-list`}>
             {state.searchList.map(treeNode => (
-              <li className={`${prefixClz}-body-list-item`}>
+              <li key={treeNode.id} className={`${prefixClz}-body-list-item`}>
                 <NodeTitle
                   item={treeNode}
                   onMouseDown={onMouseDown(treeNode)}

--- a/packages/xflow-extension/src/flowchart-node-panel/panel-body.tsx
+++ b/packages/xflow-extension/src/flowchart-node-panel/panel-body.tsx
@@ -38,8 +38,11 @@ export const NodePanelBody: React.FC<IBodyProps> = props => {
   const [dnd, setDnd] = React.useState<Addon.Dnd>()
   /** 获取graph实例 */
   const [graph, setGraph] = React.useState<Graph>()
-  graphProvider.getGraphInstance().then(x6Graph => {
-    setGraph(x6Graph)
+
+  React.useEffect(() => {
+    graphProvider.getGraphInstance().then(x6Graph => {
+      setGraph(x6Graph)
+    })
   })
 
   let graphConfig = undefined


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
在react 18下，流程图在某些情况下会出现卡死情况，如下图：
![2022-11-27 02 05 02](https://user-images.githubusercontent.com/3993655/204102831-d8ff69c0-9c2f-47d1-912f-53027bf9c9ae.gif)

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
