### PR TITLE
feat: 增加自定义 ColorPicker container 的能力

### DIFF
--- a/packages/xflow-extension/src/flowchart-editor-panel/control-map-service/components/fields/color.tsx
+++ b/packages/xflow-extension/src/flowchart-editor-panel/control-map-service/components/fields/color.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, memo } from 'react'
-import { render, createPortal } from 'react-dom'
+import { createPortal } from 'react-dom'
 import type { IGraphConfig } from '@antv/xflow-core'
 import { useXFlowApp } from '@antv/xflow-core'
 import { Button } from 'antd'
@@ -10,10 +10,11 @@ export interface IProps {
   label?: string
   value?: string
   onChange?: (value: string) => void
+  getContainer?: () => HTMLDivElement
 }
 
 const ColorPicker: React.FC<IProps> = props => {
-  const { label, value = '', onChange } = props
+  const { label, value = '', onChange, getContainer } = props
   const [show, setShow] = useState(false)
   const colorRef = useRef<string>(value)
   const containerRef = useRef<HTMLDivElement>()
@@ -60,36 +61,24 @@ const ColorPicker: React.FC<IProps> = props => {
     if (containers.length === 1) {
       return containers[0]
     }
-    let containter = null
+    let container = null
     let currentNode = currentEle.parentElement
-    while (!containter) {
+    while (!container) {
       const current = currentNode.getElementsByClassName(className)
       if (current?.length > 0) {
-        containter = current[0]
+        container = current[0]
       }
       currentNode = currentNode.parentElement
     }
-    return containter
+    return container
   }
 
-  const createPickColorContainer = (visible: boolean) => {
-    const existElements = document.getElementsByClassName(`${PREFIX}-pick-color-container`)
-    if (existElements.length) {
-      Array.from(existElements).forEach(ele => {
-        ele.parentNode?.removeChild(ele)
-      })
-    }
-    if (!visible) {
-      return
-    }
-    const div = document.createElement('div')
-    render(
-      createPortal(
-        <PickContainer />,
-        getParentContainerByClassName(containerRef.current, 'flowchart-editor-panel-body'),
-      ),
-      div,
-    )
+  const createPickColorContainer = () => {
+    const container =
+      getContainer?.() ??
+      getParentContainerByClassName(containerRef.current, 'flowchart-editor-panel-body')
+
+    return createPortal(<PickContainer />, container)
   }
 
   return (
@@ -109,7 +98,7 @@ const ColorPicker: React.FC<IProps> = props => {
           }}
         />
       </div>
-      {createPickColorContainer(show)}
+      {show && createPickColorContainer()}
     </div>
   )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
在以前的版本中，写死了 ColorPicker 组件的 container, 保证了全屏模式下，弹出窗不会被遮挡，但是 container 的层级比较深，在非全屏的模式下，会出现其他 z-index 更高的节点在它上面，且现在的结构下，没办法单纯通过调整 z-index 达到目的：
![image](https://user-images.githubusercontent.com/17964556/220864477-080657e2-01f0-40ae-9921-99737d85abce.png)

通过提供自定义 container 的能力，能让开发者更自由的挂载组件，避免遮挡的出现。

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
