### PR TITLE
Fix highlight node related lines

### DIFF
--- a/packages/xflow-core/src/command-contributions/node/node-highlight.ts
+++ b/packages/xflow-core/src/command-contributions/node/node-highlight.ts
@@ -77,14 +77,14 @@ export class HighlightNodeCommand implements ICommand {
           /** 节点关联的连线, 联动高亮 */
           if (handlerArgs?.isHighlightRelatedLines) {
             const { edgeStroke, edgeStrokeWidth } = handlerArgs
-            const allEdges = x6Graph?.getEdges()
-            allEdges.forEach((x6Edge: X6Edge) => {
-              const x6EdgeData = x6Edge?.getData<any>()
-              handlerArgs?.commandService.executeCommand(XFlowEdgeCommands.HIGHLIGHT_EDGE.id, {
-                edgeId: x6EdgeData?.id,
-                strokeColor: edgeStroke,
-                strokeWidth: edgeStrokeWidth,
-              } as NsEdgeCmd.HighlightEdge.IArgs)
+            const connectedEdges = x6Graph?.getConnectedEdges(x6Node)
+            connectedEdges.forEach((x6Edge: X6Edge) => {
+              x6Edge.setAttrs({
+                line: {
+                  stroke: edgeStroke,
+                  strokeWidth: edgeStrokeWidth,
+                }
+              })
             })
           }
         }

--- a/packages/xflow-docs/docs/api/commands/nodes/node-highlight/index.md
+++ b/packages/xflow-docs/docs/api/commands/nodes/node-highlight/index.md
@@ -28,6 +28,7 @@ XFlow 提供节点添加的命令 `XFlowNodeCommands.HIGHLIGHT_NODE`, 通过该�
 |             strokeWidth |  number |      |      - | 节点高亮边框宽度         |
 | isHighlightRelatedLines | boolean |      |      - | 是否联动高亮节点的关联边 |
 |              edgeStroke |  string |      |      - | 边高亮颜色               |
+|         edgeStrokeWidth |  number |      |      - | 边高亮宽度               |
 
 | edgeStrokeWidth?: number
 | number | | - | 边高亮宽度 |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
修复问题：XFlowNodeCommands.HIGHLIGHT_NODE 高亮节点命令，isHighlightRelatedLines参数功能不正确

问题1：getEdges是获取全部边，应该改为getConnectedEdges

问题2：在allEdges.forEach里面执行HIGHLIGHT_EDGE，会导致只高亮最后一条边，因为HIGHLIGHT_EDGE命令一次只高亮一条边，并且会将其他边重置为非高亮

<!--- Describe your changes in detail -->

### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- GIF or snapshot should be provided if includes UI/interactive modification. -->
<!--- How to fix the problem, and list final API implementation and usage sample if that is an new feature. -->

### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files)

### Self Check before Merge

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/antvis/x6/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
